### PR TITLE
appimagetool updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION=0.3.3
 BUILD=1
 
 ARCH=$(shell uname -m)
-AIA=./AppImageAssistant_6-$(ARCH).AppImage
+AIA=./appimagetool-$(ARCH).AppImage
 NATIVE_EXT=build/iris-lib/node_modules/serialport/build/Release/serialport.node
 OUT=EaselDriver-$(VERSION)-$(BUILD)-$(ARCH).AppImage
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ node to build native extensions.
 
 The following files must be present in the repo root:
 
-- AppImageAssistant_6-<..your-arch-here..>.AppImage
-- EaselDriver-0.2.6.pkg
+- appimagetool-<..your-arch-here..>.AppImage
+- EaselDriver-0.3.3.pkg
 
-AppImageAssistant is part of [AppImageKit](https://github.com/probonopd/AppImageKit). If you are targeting a
+appimagetool is part of [AppImageKit](https://github.com/probonopd/AppImageKit). If you are targeting a
 platform that doesn't have pre-built versions, you will have to clone the *AppImageKit* repo and run `build.sh`
 to build the tools.
 
-EaselDriver-0.2.6.pkg can be found via the **mac** download link from the easel setup page.
+EaselDriver-0.3.3.pkg can be found via the **mac** download link from the easel setup page.
 
 
 # Disclaimer

--- a/easel-driver.desktop
+++ b/easel-driver.desktop
@@ -2,5 +2,4 @@
 Name=EaselDriver
 Exec=AppRun
 Terminal=true
-Icon=easel.svg
-
+Icon=easel


### PR DESCRIPTION
Update makefile, documentation, and .desktop file to work with the latest AppImageKit binaries.